### PR TITLE
ECO-1049 Fix chat scroll (for firefox)

### DIFF
--- a/web/js/chatView.js
+++ b/web/js/chatView.js
@@ -167,7 +167,7 @@
     var name = data.sender || data.userName;
     var text = time + ' - ' + name + ' ' + data.text;
     insertText(item, text);
-    scrollTo(item);
+    scrollTo();
   }
 
   function insertText(elemRoot, text) {
@@ -207,12 +207,11 @@
 
     insertText(info, data.text);
 
-    scrollTo(item);
+    scrollTo();
   }
 
-  function scrollTo(item) {
-    item = item || chatContent.lastChild;
-    chatContainer.scrollTop = chatContent.offsetHeight + item.clientHeight;
+  function scrollTo() {
+    chatContainer.scrollTop = chatContent.scrollHeight - chatContent.offsetHeight;
   }
 
   function init(aUsrId, aRoomName, configuredEvts) {

--- a/web/less/chat.less
+++ b/web/less/chat.less
@@ -70,19 +70,14 @@
       overflow-y: auto;
       overflow-x: hidden;
       display: flex;
-      flex: 1;
       flex-direction: column;
       justify-content: flex-end;
-      align-items: center;
 
     ul {
       display: flex;
       flex-direction: column;
       min-height: 0;
       width: 100%;
-      max-width: 486px;
-      // justify-content: flex-end;
-
 
       li.event {
         align-self: center;
@@ -113,7 +108,7 @@
       li {
           align-self: flex-start;
           background-color: transparent;
-          padding: 10px 30px 10px 20px;
+          padding: 10px 20px 10px 20px;
           border: 0;
           color: #3f4f57;
           width: fit-content;

--- a/web/less/chat.less
+++ b/web/less/chat.less
@@ -65,20 +65,23 @@
     }
 
     #chatMsgs {
-      overflow-y: auto;
-      display: block;
+      width: 100%;
       height: calc(~"100% - 200px");
-      width: calc(~"100% + 15px");
-      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
       display: flex;
-      overflow: auto;
+      flex: 1;
+      flex-direction: column;
+      justify-content: flex-end;
+      align-items: center;
 
     ul {
       display: flex;
       flex-direction: column;
-      min-height: min-content;
+      min-height: 0;
       width: 100%;
-      justify-content: flex-end;
+      max-width: 486px;
+      // justify-content: flex-end;
 
 
       li.event {


### PR DESCRIPTION
So, this all happened because the messages now start at the bottom, which for some reason makes everything 100x harder.
I managed to make it work on chrome but it failed on firefox (hence this ticket).
I've changed the css to work, but I also had to change the scroll JS as it was scrolling to random places in the middle of the chat, probably because the scroll function was written back when messages started at the top of the chat.