### PR TITLE
[ECO-1131 / ECO-1134] and [ECO-1159] Fix assorted control bar console errors

### DIFF
--- a/web/js/itemsHandler.js
+++ b/web/js/itemsHandler.js
@@ -37,9 +37,6 @@
         case 'roomController:audio':
           var detail = evt.detail;
           var item = this.items[detail.id];
-          if (detail.reason === 'publishVideo' || detail.reason === 'publishAudio') {
-            item = this.items.publisher;
-          }
 
           if (!item) {
             return;

--- a/web/js/roomView.js
+++ b/web/js/roomView.js
@@ -386,6 +386,9 @@ BubbleFactory, Clipboard, LayoutManager */
     callControlsElem.addEventListener('click', function (e) {
       var elem = e.target;
       elem = HTMLElems.getAncestorByTagName(elem, 'button');
+      if (elem === null) {
+        return;
+      }
       switch (elem.id) {
         case 'addToCall':
           Utils.sendEvent('roomView:addToCall');


### PR DESCRIPTION
Fixes:

- ECO-1131/ECO-1134: Toggling video or audio console error. This was trying to add clases to the publisher controls on the publisher video div. These controls have been removed so removing that action for publisher. Maintaining for subscribers as these are still used.

- ECO-1159: Clicking spaces between buttons console error: Was trying to read element ID of null.