### PR TITLE
Remove usePreviousDeviceSelection warning from console

### DIFF
--- a/web/js/roomController.js
+++ b/web/js/roomController.js
@@ -852,7 +852,9 @@ RecordingsController, ScreenShareController, FeedbackController, PhoneNumberCont
           }
           publisherOptions.name = userName;
           // Remember previous device selection in IE:
-          publisherOptions.usePreviousDeviceSelection = true;
+          if (Utils.isIE()) {
+            publisherOptions.usePreviousDeviceSelection = true;
+          }
           return otHelper.publish(publisherElement, publisherOptions, {}).then(function () {
             setPublisherReady();
             RoomView.showPublisherButtons(publisherOptions);


### PR DESCRIPTION
This prevents a warning from being logged in the console in browsers
other than IE.