### PR TITLE
[ECO-1205][ECO-1210]redraw annotation canvas on publisher resize

### DIFF
--- a/web/js/chatView.js
+++ b/web/js/chatView.js
@@ -26,12 +26,15 @@
     if (isVisible) {
       addHandlers();
       return Chat.show().then(function () {
+        Utils.sendEvent('chatView:shown');
         scrollTo();
         chatMsgInput.focus();
       });
     }
     removeHandlers();
-    return Chat.hide();
+    return Chat.hide().then(function () {
+      Utils.sendEvent('chatView:hidden');
+    });
   }
 
   var eventHandlers;
@@ -128,7 +131,6 @@
     evt.preventDefault();
     evt.stopImmediatePropagation();
     _visibilityChanging = setVisibility(false);
-    Utils.sendEvent('chatView:hidden');
   };
 
   var onToggle = function () {

--- a/web/js/helpers/OTHelper.js
+++ b/web/js/helpers/OTHelper.js
@@ -3,6 +3,7 @@
 
   var dynamicOTLoad = true;
   var otPromise = Promise.resolve();
+  var annotation;
 
   var preReqSources = [
   ];
@@ -410,11 +411,18 @@
       };
       return new AnnotationAccPack(options);
     }
+    function resizeAnnotationCanvas () {
+      annotation && annotation.resizeCanvas();
+    }
 
     function startAnnotation(aAccPack) {
       if (!aAccPack) {
         return Promise.resolve();
       }
+      annotation = aAccPack;
+      Utils.addEventsHandlers('roomView:', {
+        screenChange: resizeAnnotationCanvas
+      });
       return aAccPack.start(_session, {
         imageAssets: IMAGE_ASSETS,
         backgroundColor: TOOLBAR_BG_COLOR
@@ -425,6 +433,10 @@
     function endAnnotation(aElement) {
       var annPack =  aElement && aElement._ANNOTATION_PACK || aElement;
       annPack && annPack.end && annPack.end();
+      Utils.removeEventHandlers('roomView:', {
+        screenChange: resizeAnnotationCanvas
+      });
+      annotation = null;
     }
 
     function setupAnnotation(aAccPack, aPubSub, aParentElement) {

--- a/web/js/layoutManager.js
+++ b/web/js/layoutManager.js
@@ -145,10 +145,10 @@ LayoutViewport, ItemsHandler */
     if (!currentLayout || !isOnGoing(CandidateLayout)) {
       currentLayout && currentLayout.destroy();
       currentLayout = new CandidateLayout(container, items, item);
-      Utils.sendEvent('layoutManager:layoutChanged');
     }
 
     currentLayout.rearrange();
+    Utils.sendEvent('layoutManager:layoutChanged');
     updateAvailableLayouts();
   }
 

--- a/web/js/layoutManager.js
+++ b/web/js/layoutManager.js
@@ -145,10 +145,10 @@ LayoutViewport, ItemsHandler */
     if (!currentLayout || !isOnGoing(CandidateLayout)) {
       currentLayout && currentLayout.destroy();
       currentLayout = new CandidateLayout(container, items, item);
+      Utils.sendEvent('layoutManager:layoutChanged');
     }
 
     currentLayout.rearrange();
-    Utils.sendEvent('layoutManager:layoutChanged');
     updateAvailableLayouts();
   }
 

--- a/web/js/layouts.js
+++ b/web/js/layouts.js
@@ -16,6 +16,7 @@ LayoutBase.prototype = {
       });
     }, this);
     this.flush();
+    Utils.sendEvent('hangout:rearranged');
     return this;
   },
 

--- a/web/js/libs/browser_utils.js
+++ b/web/js/libs/browser_utils.js
@@ -53,6 +53,13 @@
     });
   };
 
+  var removeEventHandlers = function (eventPreffixName, handlers, target) {
+    eventPreffixName = eventPreffixName || '';
+    Object.keys(handlers).forEach(function (eventName) {
+      (target || exports).removeEventListener(eventPreffixName + eventName, handlers[eventName]);
+    });
+  };
+
   var setTransform = function (style, transform) {
     /* eslint-disable no-multi-assign */
     style.MozTransform = style.webkitTransform = style.msTransform = style.transform = transform;
@@ -201,6 +208,7 @@
     inspectObject: inspectObject,
     sendEvent: sendEvent,
     addEventsHandlers: addEventsHandlers,
+    removeEventHandlers: removeEventHandlers,
     addHandlers: addHandlers,
     get draggableUI() {
       return document.querySelectorAll('[draggable]').length;

--- a/web/js/roomController.js
+++ b/web/js/roomController.js
@@ -580,6 +580,10 @@ RecordingsController, ScreenShareController, FeedbackController, PhoneNumberCont
           .then(function (subscriber) {
             if (streamVideoType === 'screen') {
               enableAnnotations && Utils.sendEvent('roomController:annotationStarted');
+              var subContainer = subscriber.element.parentElement;
+              Utils.sendEvent('layoutView:itemSelected', {
+                item: subContainer
+              });
               return subscriber;
             }
 

--- a/web/js/roomView.js
+++ b/web/js/roomView.js
@@ -128,12 +128,6 @@ BubbleFactory, Clipboard, LayoutManager */
     }
   };
 
-  var layoutManagerEvents = {
-    layoutChanged: function () {
-      Utils.sendEvent('roomView:screenChange');
-    }
-  };
-
   var hangoutEvents = {
     screenOnStage: function (event) {
       var status = event.detail.status;
@@ -145,6 +139,9 @@ BubbleFactory, Clipboard, LayoutManager */
           dock.classList.remove('collapsed');
         dock.data('previouslyCollapsed', null);
       }
+    },
+    rearranged: function () {
+      Utils.sendEvent('roomView:screenChange');
     }
   };
 
@@ -465,6 +462,7 @@ BubbleFactory, Clipboard, LayoutManager */
         case 'annotate':
           document.body.data('annotationVisible') === 'true' ?
             document.body.data('annotationVisible', 'false') : document.body.data('annotationVisible', 'true');
+          Utils.sendEvent('roomView:screenChange');
           break;
         case 'message-btn':
           setChatStatus(!messageButtonElem.classList.contains('activated'));
@@ -578,7 +576,6 @@ BubbleFactory, Clipboard, LayoutManager */
     Utils.addEventsHandlers('chat:', chatEvents);
     Utils.addEventsHandlers('chatView:', chatViews);
     Utils.addEventsHandlers('hangout:', hangoutEvents);
-    Utils.addEventsHandlers('layoutManager:', layoutManagerEvents);
   };
 
   function toggleScreenSharing(evt) {

--- a/web/js/roomView.js
+++ b/web/js/roomView.js
@@ -110,6 +110,12 @@ BubbleFactory, Clipboard, LayoutManager */
       if (!_chatHasBeenShown) {
         setChatStatus(true);
       }
+    },
+    hidden: function () {
+      Utils.sendEvent('roomView:screenChange');
+    },
+    shown: function () {
+      Utils.sendEvent('roomView:screenChange');
     }
   };
 
@@ -119,6 +125,12 @@ BubbleFactory, Clipboard, LayoutManager */
       messageButtonElem.classList.remove('activated');
       setUnreadMessages(0);
       HTMLElems.flush('#toggleChat');
+    }
+  };
+
+  var layoutManagerEvents = {
+    layoutChanged: function () {
+      Utils.sendEvent('roomView:screenChange');
     }
   };
 
@@ -566,6 +578,7 @@ BubbleFactory, Clipboard, LayoutManager */
     Utils.addEventsHandlers('chat:', chatEvents);
     Utils.addEventsHandlers('chatView:', chatViews);
     Utils.addEventsHandlers('hangout:', hangoutEvents);
+    Utils.addEventsHandlers('layoutManager:', layoutManagerEvents);
   };
 
   function toggleScreenSharing(evt) {

--- a/web/js/vendor/opentok-annotation.js
+++ b/web/js/vendor/opentok-annotation.js
@@ -2146,7 +2146,7 @@
   }, 1000);
 
   /** Resize the canvas to match the size of its container */
-  var _resizeCanvas = function () {
+  var _resizeCanvas = _.throttle(function () {
     var width;
     var height;
 
@@ -2183,16 +2183,14 @@
 
     _refreshCanvas();
     _triggerEvent('resizeCanvas');
-  };
+  }, 500, {trailing: false});
 
   var _changeColorByIndex = function(colorIndex) {
     _canvas.changeColorByIndex(colorIndex);
   };
 
   var _listenForResize = function () {
-    $(_elements.resizeSubject).on('resize', _.throttle(function () {
-      _resizeCanvas();
-    }, 500));
+    $(_elements.resizeSubject).on('resize', _resizeCanvas);
   };
 
   var _createToolbar = function (session, options, externalWindow) {

--- a/web/less/room.less
+++ b/web/less/room.less
@@ -897,6 +897,17 @@ footer.main {
   background-color: @mainBackgroundColor;
 }
 
+
+#opentok_canvas {
+  pointer-events: none;
+}
+
+body[data-annotation-visible=true]  {
+  #opentok_canvas {
+    pointer-events: auto;
+  }
+}
+
 .dragging {
   pointer-events: none;
 }


### PR DESCRIPTION
In the PR:
- Redraw canvas after layout changes, text chat opening, annotation tools opening... anything that should change the canvas position other than window resizing which is already dealth with
- Turn off canvas pointer events while annotation tools not open, essentially this means you will not be annotating unless you click the annotation button, which makes sense. This also fixes eco-1210 where double-clicking the canvas didn't change the layout. This will still be true if you are actually annotating but I think that's ok
- Fix an existing bug where the window was still being watched after annotation stopped and caused a bunch of console errors. This error was in the acc-pack itself, but we don't use npm for this package so had to change locally too. I also added the changes to the acc-pack repo https://github.com/opentok/accelerator-annotation-js/pull/21
- Give screenshare stream large layout on subscribe