### PR TITLE
Make firebase env vars optional in heroku deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,19 +16,19 @@
   "env": {
     "TB_API_KEY": {
       "description": "OpenTok API key: Login to the Tokbox Dashboard (https://dashboard.tokbox.com/keys) to get this value.",
-      "required": "true"
+      "required": true
     },
     "TB_API_SECRET": {
       "description": "OpenTok API secret: Login to the Tokbox Dashboard (https://dashboard.tokbox.com/keys) to get this value.",
-      "required": "true"
+      "required": true
     },
     "FB_DATA_URL": {
       "description": "URL of the Firebase app used to store the archive information. Go to https://firebase.com to get a valid URL.",
-      "required": "false"
+      "required": false
     },
     "FB_AUTH_SECRET": {
       "description": "Firebase Auth secret for the database. Go to https://firebase.com to get a valid URL and secret.",
-      "required": "false"
+      "required": false
     }
   },
   "addons": [


### PR DESCRIPTION
These values need to be boolean not string. This fixes so that the firebase vars are optional when deploying to with button to heroku. 
FYI trying the button off this branch won't work because it will still use the `app.json` from `opentok/OpenTokRTC-V2#master`. You can try a button with different target repo here to check this change works here https://github.com/maikthomas/OpenTokRTC-V2/blob/heroku-button-fix-test/INSTALL-heroku.md