### PR TITLE
Fix "pm" string in Utils.getCurrentTime().

### DIFF
--- a/web/js/libs/browser_utils.js
+++ b/web/js/libs/browser_utils.js
@@ -8,7 +8,7 @@
     var suffix = ' AM';
 
     var hours = now.getHours();
-    if (hours > 12) {
+    if (hours >= 12) {
       suffix = ' PM';
       hours -= 12;
     }


### PR DESCRIPTION
Replaces this PR: https://github.com/opentok/OpenTokRTC-V2/pull/436.